### PR TITLE
[wasi-bindgen] Do not use serde-serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
 name = "js-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,29 +111,6 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "serde"
-version = "1.0.158"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
-
-[[package]]
-name = "serde_json"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -220,8 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ js-sys = "0.3.61"
 rexie = "0.4.2"
 thiserror = "1.0.40"
 tokio = { version = "1.26.0", features = ["sync"] }
-wasm-bindgen = { version = "0.2.84", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.84" }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["rt", "macros"] }


### PR DESCRIPTION
`wasi-bindgen`'s `serde-serialize` feature has been deprecated in favour of the `serde-wasm-bindgen` crate. See https://github.com/rustwasm/wasm-bindgen/pull/3031 for more context, but in SurrealDB's case, it causes a dependency cycle when I try to add certain dependencies:
```
error: cyclic package dependency: package `getrandom v0.2.9` depends on itself. Cycle:
package `getrandom v0.2.9`
```

I checked all SurrealDB dependencies and they don't include the `serde-serialize` feature. Except for this one.

I was expecting `cargo build` or `cargo test` to fail, but they succeeded, so I assume the feature was not being used.